### PR TITLE
NET5 and AllocConsole

### DIFF
--- a/Coroutines/Coroutines.csproj
+++ b/Coroutines/Coroutines.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>

--- a/Coroutines/Program.cs
+++ b/Coroutines/Program.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -146,8 +147,13 @@ namespace Coroutines
         }
         #endregion
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool AllocConsole();
+
         public static void Main()
         {
+            AllocConsole();
             Console.Title = Application.ProductName;
             Console.Clear();
             Console.CursorVisible = false;


### PR DESCRIPTION
Update for .NET5, changed the app type to Windows (from Console) and added `AllocConsole` to workaround issue #1 (thanks @ted-dgk for reporting!).  